### PR TITLE
dev-util/gitlab-ci-multi-runner: Fix binary installation.

### DIFF
--- a/dev-util/gitlab-ci-multi-runner/gitlab-ci-multi-runner-1.10.0.ebuild
+++ b/dev-util/gitlab-ci-multi-runner/gitlab-ci-multi-runner-1.10.0.ebuild
@@ -40,6 +40,6 @@ src_compile() {
 }
 
 src_install() {
-	dobin bin/*
+	newbin src/${EGO_PN%/*}/out/binaries/gitlab-ci-multi-runner-linux-amd64 gitlab-ci-multi-runner
 	dodoc src/${EGO_PN%/*}/README.md src/${EGO_PN%/*}/CHANGELOG.md
 }


### PR DESCRIPTION
Looking at the differences between 1.9.5 and 1.10.0, it's unclear why
the behaviour here changed. Since this package is currently supported
for only ~amd64, we can simply grab the relevant binary and install it.